### PR TITLE
Add ON_PREM_API_KEY for dedicated on-prem API authentication.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,12 +52,16 @@ npm install
 
 ### 2. Setup Environment
 
-Create `.env.local`:
+See [`docs/API_AUTHENTICATION.md`](./docs/API_AUTHENTICATION.md) for API keys. Create `.env.local` with:
 
 ```bash
 # Supabase Configuration
 NEXT_PUBLIC_SUPABASE_URL=https://your-project.supabase.co
 NEXT_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
+
+# POST /api/services/status — at least one key required
+EXTERNAL_API_KEY=your-cloud-saas-key
+ON_PREM_API_KEY=your-on-prem-only-key   # optional; use for drdroid-on-prem installs
 
 NEXT_PUBLIC_HYPERLOOK_API_KEY=your-hyperlook-key
 

--- a/app/api/services/status/route.ts
+++ b/app/api/services/status/route.ts
@@ -1,38 +1,43 @@
 import { NextRequest, NextResponse } from "next/server";
 import { supabase } from "@/lib/supabase";
 
-// API Key for authentication - read from environment variable
-const API_KEY = process.env.EXTERNAL_API_KEY;
+/** Cloud / SaaS clients (e.g. aiops-v0). */
+const EXTERNAL_API_KEY = process.env.EXTERNAL_API_KEY?.trim() || "";
+/** On-prem DrDroid installs only — separate key for rotation and auditing. */
+const ON_PREM_API_KEY = process.env.ON_PREM_API_KEY?.trim() || "";
 
-if (!API_KEY) {
+const ALLOWED_API_KEYS = new Set(
+  [EXTERNAL_API_KEY, ON_PREM_API_KEY].filter((key) => key.length > 0),
+);
+
+if (ALLOWED_API_KEYS.size === 0) {
   console.error(
-    "EXTERNAL_API_KEY environment variable is not set. API authentication will fail.",
+    "Neither EXTERNAL_API_KEY nor ON_PREM_API_KEY is set. API authentication will fail.",
   );
 }
 
-// Helper function to validate API key from request headers
+function extractApiKeyFromRequest(request: NextRequest): string | null {
+  const authHeader = request.headers.get("authorization");
+  if (authHeader) {
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    if (token) return token;
+  }
+
+  const apiKeyHeader = request.headers.get("x-api-key");
+  if (apiKeyHeader) {
+    return apiKeyHeader.trim();
+  }
+
+  return null;
+}
+
 function validateApiKey(request: NextRequest): boolean {
-  // If API key is not configured, reject all requests
-  if (!API_KEY) {
+  if (ALLOWED_API_KEYS.size === 0) {
     return false;
   }
 
-  // Check for API key in Authorization header (Bearer token)
-  const authHeader = request.headers.get("authorization");
-  if (authHeader) {
-    const token = authHeader.replace("Bearer ", "").trim();
-    if (token === API_KEY) {
-      return true;
-    }
-  }
-
-  // Check for API key in X-API-Key header
-  const apiKeyHeader = request.headers.get("x-api-key");
-  if (apiKeyHeader && apiKeyHeader === API_KEY) {
-    return true;
-  }
-
-  return false;
+  const token = extractApiKeyFromRequest(request);
+  return token !== null && ALLOWED_API_KEYS.has(token);
 }
 
 // Helper function to normalize service identifier to slug (case-insensitive)

--- a/docs/API_AUTHENTICATION.md
+++ b/docs/API_AUTHENTICATION.md
@@ -1,0 +1,27 @@
+# API authentication (`POST /api/services/status`)
+
+Clients must send a valid key via `Authorization: Bearer <key>` or `X-API-Key`.
+
+## Environment variables (Render / Vercel)
+
+| Variable | Used by |
+|----------|---------|
+| `EXTERNAL_API_KEY` | Cloud SaaS (aiops-v0, Falcon) |
+| `ON_PREM_API_KEY` | DrDroid on-prem installs only |
+
+At least one must be set. Both may be set with **different** values so you can rotate or revoke on-prem access independently.
+
+Generate a new key:
+
+```bash
+python3 -c "import secrets; print(secrets.token_urlsafe(32))"
+```
+
+## On-prem (drdroid-on-prem)
+
+1. Set `ON_PREM_API_KEY` on the status-page-aggregator deployment (Render).
+2. Set the **same value** in Helm as `secrets.statusPageApiKey` (injected as `STATUS_PAGE_API_KEY` in podracer/falcon).
+
+## Cloud (aiops-v0)
+
+Set `EXTERNAL_API_KEY` on the aggregator and `STATUS_PAGE_API_KEY` on clients to the same value.


### PR DESCRIPTION
Accept EXTERNAL_API_KEY or ON_PREM_API_KEY on POST /api/services/status so cloud and on-prem clients can use separate rotatable keys.