### PR TITLE
Add live cloud feed fallback to status API for Azure.

### DIFF
--- a/app/api/cloud-status/route.ts
+++ b/app/api/cloud-status/route.ts
@@ -1,54 +1,28 @@
 import { NextResponse } from "next/server";
-import {
-  fetchServiceStatus,
-  fetchServiceStatusFromAtom,
-} from "@/lib/status";
 import { statusMapEntryFromLive } from "@/lib/enrichStatusMap";
-
-const CLOUD_FEEDS = {
-  aws: {
-    type: "rss" as const,
-    url: "https://status.aws.amazon.com/rss/all.rss",
-  },
-  "google-cloud": {
-    type: "atom" as const,
-    url: "https://status.cloud.google.com/en/feed.atom",
-  },
-  azure: {
-    type: "rss" as const,
-    url: "https://azure.status.microsoft/en-us/status/feed/",
-  },
-};
+import { fetchLiveCloudStatus } from "@/lib/fetchLiveCloudStatus";
 
 /** Live fetch for core cloud providers when Supabase rows are missing. */
 export async function GET() {
   try {
-    const results: Record<
+    const live = await fetchLiveCloudStatus();
+    const providers: Record<
       string,
       ReturnType<typeof statusMapEntryFromLive>
     > = {};
 
-    await Promise.all(
-      Object.entries(CLOUD_FEEDS).map(async ([slug, feed]) => {
-        const data =
-          feed.type === "atom"
-            ? await fetchServiceStatusFromAtom(feed.url)
-            : await fetchServiceStatus(feed.url);
-
-        results[slug] = statusMapEntryFromLive(
-          data.status,
-          data.lastIncident?.createdAt
-            ? { createdAt: data.lastIncident.createdAt }
-            : undefined,
-        );
-      }),
-    );
+    for (const [slug, row] of live) {
+      providers[slug] = statusMapEntryFromLive(
+        row.status,
+        row.last_incident ? { createdAt: row.last_incident } : undefined,
+      );
+    }
 
     return NextResponse.json({
       success: true,
       source: "live-feed",
       updated_at: new Date().toISOString(),
-      providers: results,
+      providers,
     });
   } catch (error: unknown) {
     const message = error instanceof Error ? error.message : String(error);

--- a/app/api/services/status/route.ts
+++ b/app/api/services/status/route.ts
@@ -1,4 +1,8 @@
 import { NextRequest, NextResponse } from "next/server";
+import {
+  fetchLiveCloudStatus,
+  isCloudCanonicalSlug,
+} from "@/lib/fetchLiveCloudStatus";
 import { expandSlugQuery, resolveServiceSlug } from "@/lib/serviceSlugAliases";
 import { supabase } from "@/lib/supabase";
 
@@ -45,6 +49,25 @@ function validateApiKey(request: NextRequest): boolean {
 function normalizeToSlug(identifier: string): string {
   // Convert to lowercase and replace spaces with hyphens
   return identifier.toLowerCase().trim().replace(/\s+/g, "-");
+}
+
+type StatusRow = {
+  service_slug: string;
+  status: string;
+  last_incident: string | null;
+  last_incident_details: unknown;
+  updated_at: string | null;
+};
+
+function lookupStatusFromMap(
+  map: Map<string, StatusRow>,
+  canonicalSlug: string,
+): StatusRow | undefined {
+  for (const key of expandSlugQuery([canonicalSlug])) {
+    const row = map.get(key);
+    if (row) return row;
+  }
+  return undefined;
 }
 
 export async function POST(request: NextRequest) {
@@ -106,18 +129,30 @@ export async function POST(request: NextRequest) {
     }
 
     // Create a map for quick lookup
-    const statusMap = new Map(
-      data?.map((row) => [row.service_slug, row]) || [],
+    const statusMap = new Map<string, StatusRow>(
+      data?.map((row) => [row.service_slug, row as StatusRow]) || [],
     );
 
-    // Build response with all requested services
-    const lookupStatus = (canonicalSlug: string) => {
-      for (const key of expandSlugQuery([canonicalSlug])) {
-        const row = statusMap.get(key);
-        if (row) return row;
+    // Same live-feed fallback as the dashboard when Supabase lacks cloud rows
+    const missingCloud = [...new Set(slugs)]
+      .filter(isCloudCanonicalSlug)
+      .filter((slug) => !lookupStatusFromMap(statusMap, slug));
+
+    if (missingCloud.length > 0) {
+      const liveCloud = await fetchLiveCloudStatus(missingCloud);
+      for (const [slug, row] of liveCloud) {
+        statusMap.set(slug, {
+          service_slug: slug,
+          status: row.status,
+          last_incident: row.last_incident,
+          last_incident_details: row.last_incident_details,
+          updated_at: row.updated_at,
+        });
       }
-      return undefined;
-    };
+    }
+
+    const lookupStatus = (canonicalSlug: string) =>
+      lookupStatusFromMap(statusMap, canonicalSlug);
 
     const results = serviceIdentifiers.map(
       (identifier: string, index: number) => {

--- a/lib/fetchLiveCloudStatus.ts
+++ b/lib/fetchLiveCloudStatus.ts
@@ -1,0 +1,86 @@
+import {
+  fetchServiceStatus,
+  fetchServiceStatusFromAtom,
+  type ServiceStatus,
+} from "@/lib/status";
+
+export const CLOUD_CANONICAL_SLUGS = ["aws", "google-cloud", "azure"] as const;
+export type CloudCanonicalSlug = (typeof CLOUD_CANONICAL_SLUGS)[number];
+
+const CLOUD_FEEDS: Record<
+  CloudCanonicalSlug,
+  { type: "rss" | "atom"; url: string }
+> = {
+  aws: {
+    type: "rss",
+    url: "https://status.aws.amazon.com/rss/all.rss",
+  },
+  "google-cloud": {
+    type: "atom",
+    url: "https://status.cloud.google.com/en/feed.atom",
+  },
+  azure: {
+    type: "rss",
+    url: "https://azure.status.microsoft/en-us/status/feed/",
+  },
+};
+
+export type LiveCloudStatusRow = {
+  service_slug: CloudCanonicalSlug;
+  status: ServiceStatus;
+  last_incident: string | null;
+  last_incident_details: {
+    title: string;
+    description: string;
+    status: string;
+    createdAt: string;
+    updatedAt: string;
+    components: string[];
+  } | null;
+  updated_at: string;
+  source: "live-feed";
+};
+
+export async function fetchLiveCloudStatus(
+  slugs: CloudCanonicalSlug[] = [...CLOUD_CANONICAL_SLUGS],
+): Promise<Map<CloudCanonicalSlug, LiveCloudStatusRow>> {
+  const results = new Map<CloudCanonicalSlug, LiveCloudStatusRow>();
+  const now = new Date().toISOString();
+
+  await Promise.all(
+    slugs.map(async (slug) => {
+      const feed = CLOUD_FEEDS[slug];
+      const data =
+        feed.type === "atom"
+          ? await fetchServiceStatusFromAtom(feed.url)
+          : await fetchServiceStatus(feed.url);
+
+      const lastIncident = data.lastIncident;
+      results.set(slug, {
+        service_slug: slug,
+        status: data.status,
+        last_incident: lastIncident?.createdAt ?? null,
+        last_incident_details: lastIncident
+          ? {
+              title: lastIncident.title,
+              description: lastIncident.description,
+              status: lastIncident.status,
+              createdAt: lastIncident.createdAt,
+              updatedAt: lastIncident.updatedAt,
+              components: lastIncident.components,
+            }
+          : null,
+        updated_at: now,
+        source: "live-feed",
+      });
+    }),
+  );
+
+  return results;
+}
+
+export function isCloudCanonicalSlug(
+  slug: string,
+): slug is CloudCanonicalSlug {
+  return (CLOUD_CANONICAL_SLUGS as readonly string[]).includes(slug);
+}


### PR DESCRIPTION
Match dashboard behavior: when Supabase lacks azure/aws/gcp rows, fetch official RSS/Atom feeds so check_provider_status returns operational.